### PR TITLE
Configuring timeouts in config files instead of the spec files

### DIFF
--- a/protractor/config.ts
+++ b/protractor/config.ts
@@ -3,7 +3,10 @@ import { reporter } from './helpers/reporter';
 
 export const config: Config = {
   framework: 'jasmine',
-  getPageTimeout: 1000,
+  jasmineNodeOpts: {
+    defaultTimeoutInterval: 120000
+  },
+  getPageTimeout: 30000,
   SELENIUM_PROMISE_MANAGER: false,
   specs: ['../test/*.spec.js'],
   noGlobals: true,

--- a/protractor/headless.config.ts
+++ b/protractor/headless.config.ts
@@ -3,7 +3,10 @@ import { reporter } from './helpers/reporter';
 
 export const config: Config = {
   framework: 'jasmine',
-  getPageTimeout: 1000,
+  jasmineNodeOpts: {
+    defaultTimeoutInterval: 120000
+  },
+  getPageTimeout: 30000,
   SELENIUM_PROMISE_MANAGER: false,
   specs: ['../test/*.spec.js'],
   noGlobals: true,

--- a/test/buyTshirt.spec.ts
+++ b/test/buyTshirt.spec.ts
@@ -25,10 +25,6 @@ describe('Buy a t-shirt', () => {
  const bankPaymentStepPage: BankPaymentStepPage = new BankPaymentStepPage();
  const orderResumePage: OrderResumePage = new OrderResumePage();
 
- beforeEach(() => {
-   jasmine.DEFAULT_TIMEOUT_INTERVAL = 120000;
- });
-
  it('then should be bought a t-shirt', async () => {
     await browser.get('http://automationpractice.com/');
     await menuContentPage.goToShirtMenu();


### PR DESCRIPTION
Added jasmine timeouts and Protractor's getPageTimeout settings into the configurations files, instead of inside the spec files